### PR TITLE
add "node_modules" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cookbooks/python/openai/data/hotel_invoices/transformed_invoice_json/*
 cookbooks/python/openai/data/hotel_invoices/extracted_invoice_json/*
 cookbooks/python/openai/data/hotel_invoices/hotel_DB.db
 cookbooks/python/openai/hallucination_results.csv
+node_modules


### PR DESCRIPTION
Add `node_modules` to `.gitignore` to avoid repos built using the template storing dependencies.