### PR TITLE
Fix LangChain cookbook error

### DIFF
--- a/cookbooks/python/langchain/lc_openai_getting_started.ipynb
+++ b/cookbooks/python/langchain/lc_openai_getting_started.ipynb
@@ -22,7 +22,8 @@
    "source": [
     "%pip install langchain-openai\n",
     "%pip install langchain-community\n",
-    "%pip install faiss-cpu"
+    "%pip install faiss-cpu"\n",
+    "%pip install beautifulsoup4"
    ]
   },
   {
@@ -187,6 +188,8 @@
    "source": [
     "from langchain_community.document_loaders import WebBaseLoader\n",
     "\n",
+    "# Set the USER_AGENT environment variable which is required for the WebBaseLoader to load the page\n",
+    "os.environ['USER_AGENT'] = \"YourUserAgentString\"\n",
     "loader = WebBaseLoader(\"https://en.wikipedia.org/wiki/Eurovision_Song_Contest_2024\")\n",
     "\n",
     "docs = loader.load()\n",

--- a/cookbooks/python/langchain/lc_openai_getting_started.ipynb
+++ b/cookbooks/python/langchain/lc_openai_getting_started.ipynb
@@ -22,7 +22,7 @@
    "source": [
     "%pip install langchain-openai\n",
     "%pip install langchain-community\n",
-    "%pip install faiss-cpu"\n",
+    "%pip install faiss-cpu\n",
     "%pip install beautifulsoup4"
    ]
   },


### PR DESCRIPTION
This pull request includes updates to the `lc_openai_getting_started.ipynb` notebook to enhance its functionality and usability. The most important changes include adding new package installations and setting an environment variable required for web scraping.

Package installations:

* [`cookbooks/python/langchain/lc_openai_getting_started.ipynb`](diffhunk://#diff-32a048d1fd10a96f05c2f0201d944d2a1b195d75d20a45bf077e0450d88c5b6aL25-R26): Added installation of `beautifulsoup4` to the list of packages.

Environment variable setup:

* [`cookbooks/python/langchain/lc_openai_getting_started.ipynb`](diffhunk://#diff-32a048d1fd10a96f05c2f0201d944d2a1b195d75d20a45bf077e0450d88c5b6aR191-R192): Added a line to set the `USER_AGENT` environment variable, which is required for the `WebBaseLoader` to load web pages.